### PR TITLE
prepend the confluence base url when iterating in fetchSpacePages

### DIFF
--- a/internal/adapter/confluence.go
+++ b/internal/adapter/confluence.go
@@ -375,7 +375,13 @@ func (c *ConfluenceAdapter) fetchSpacePages(ctx context.Context, spaceID string)
 		if !ok {
 			break
 		}
+		// Check if nextURL doesn't start with https
+		if nextURL != "" && !strings.HasPrefix(nextURL, "https") {
+			// Prepend the base URL
+			nextURL = c.config.BaseURL + nextURL
+		}
 
+		url = nextURL
 		url = nextURL
 	}
 
@@ -396,7 +402,6 @@ func (c *ConfluenceAdapter) fetchPageByID(ctx context.Context, pageID string) (C
 	req.Header.Set("Accept", "application/json")
 
 	logrus.Debugf("Confluence page API URL: %s", url)
-
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return ConfluencePage{}, fmt.Errorf("failed to make request: %w", err)


### PR DESCRIPTION
When The fetchSpacePages method gets a paginated response and we are iterating over the Response pages, the baseurl is not prepended to the url and the next request is failing.