### PR TITLE
Feature/add markdown parsing option for confluence adapter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM --platform=$BUILDPLATFORM golang:1.21-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23.0-alpine AS builder
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,24 +1,26 @@
 module github.com/openwebui-content-sync
 
-go 1.21
+go 1.23.0
 
 require (
+	github.com/JohannesKaufmann/html-to-markdown/v2 v2.4.0
 	github.com/google/go-github/v56 v56.0.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/sirupsen/logrus v1.9.3
+	golang.org/x/net v0.43.0
 	golang.org/x/oauth2 v0.15.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
+	github.com/JohannesKaufmann/dom v0.2.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
 	github.com/stretchr/testify v1.8.4 // indirect
-	golang.org/x/net v0.19.0 // indirect
-	golang.org/x/sys v0.15.0 // indirect
+	golang.org/x/sys v0.35.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/JohannesKaufmann/dom v0.2.0 h1:1bragmEb19K8lHAqgFgqCpiPCFEZMTXzOIEjuxkUfLQ=
+github.com/JohannesKaufmann/dom v0.2.0/go.mod h1:57iSUl5RKric4bUkgos4zu6Xt5LMHUnw3TF1l5CbGZo=
+github.com/JohannesKaufmann/html-to-markdown/v2 v2.4.0 h1:C0/TerKdQX9Y9pbYi1EsLr5LDNANsqunyI/btpyfCg8=
+github.com/JohannesKaufmann/html-to-markdown/v2 v2.4.0/go.mod h1:OLaKh+giepO8j7teevrNwiy/fwf8LXgoc9g7rwaE1jk=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -39,12 +43,16 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.19.0 h1:zTwKpTd2XuCqf8huc7Fo2iSy+4RHPd10s4KzeTnVr1c=
 golang.org/x/net v0.19.0/go.mod h1:CfAk/cbD4CthTvqiEl8NpboMuiuOYsAr/7NOjZJtv1U=
+golang.org/x/net v0.43.0 h1:lat02VYK2j4aLzMzecihNvTlJNQUq316m2Mr9rnM6YE=
+golang.org/x/net v0.43.0/go.mod h1:vhO1fvI4dGsIjh73sWfUVjj3N7CA9WkKJNQm2svM6Jg=
 golang.org/x/oauth2 v0.15.0 h1:s8pnnxNVzjWyrvYdFUQq5llS1PX2zhPXmccZv99h7uQ=
 golang.org/x/oauth2 v0.15.0/go.mod h1:q48ptWNTY5XWf+JNten23lcvHpLJ0ZSxF5ttTHKVCAM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
 golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
+golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/internal/adapter/confluence.go
+++ b/internal/adapter/confluence.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/JohannesKaufmann/html-to-markdown/v2"
 	"github.com/openwebui-content-sync/internal/config"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/html"
@@ -558,11 +559,24 @@ func (c *ConfluenceAdapter) fetchPageBody(ctx context.Context, pageID string) (s
 
 	// Extract content from body.view.value
 	if page.Body.View.Value != "" {
-		// Convert HTML to plain text
+		// Convert HTML to plain text or markdown based on configuration
+		if c.config.UseMarkdownParser {
+			return c.HtmlToMarkdown(page.Body.View.Value), nil
+		}
 		return c.HtmlToText(page.Body.View.Value), nil
 	}
 
 	return "", fmt.Errorf("no content found in page body")
+}
+
+// HtmlToMarkdown converts HTML content to markdown
+func (c *ConfluenceAdapter) HtmlToMarkdown(htmlContent string) string {
+	markdown, err := htmltomarkdown.ConvertString(htmlContent)
+	if err != nil {
+		logrus.Warnf("Failed to convert HTML to markdown: %v", err)
+		return htmlContent
+	}
+	return markdown
 }
 
 // htmlToText converts HTML content to plain text

--- a/internal/adapter/confluence.go
+++ b/internal/adapter/confluence.go
@@ -382,7 +382,6 @@ func (c *ConfluenceAdapter) fetchSpacePages(ctx context.Context, spaceID string)
 		}
 
 		url = nextURL
-		url = nextURL
 	}
 
 	return allPages, nil

--- a/internal/adapter/confluence.go
+++ b/internal/adapter/confluence.go
@@ -13,10 +13,10 @@ import (
 	"strings"
 	"time"
 
-	converter "github.com/JohannesKaufmann/html-to-markdown/v2/converter"
+	"github.com/JohannesKaufmann/html-to-markdown/v2/converter"
 	"github.com/JohannesKaufmann/html-to-markdown/v2/plugin/base"
 	"github.com/JohannesKaufmann/html-to-markdown/v2/plugin/commonmark"
-	table "github.com/JohannesKaufmann/html-to-markdown/v2/plugin/table"
+	"github.com/JohannesKaufmann/html-to-markdown/v2/plugin/table"
 	"github.com/openwebui-content-sync/internal/config"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/html"

--- a/internal/adapter/confluence.go
+++ b/internal/adapter/confluence.go
@@ -375,7 +375,13 @@ func (c *ConfluenceAdapter) fetchSpacePages(ctx context.Context, spaceID string)
 		if !ok {
 			break
 		}
+		// Check if nextURL doesn't start with https
+		if nextURL != "" && !strings.HasPrefix(nextURL, "https") {
+			// Prepend the base URL
+			nextURL = c.config.BaseURL + nextURL
+		}
 
+		url = nextURL
 		url = nextURL
 	}
 
@@ -396,7 +402,6 @@ func (c *ConfluenceAdapter) fetchPageByID(ctx context.Context, pageID string) (C
 	req.Header.Set("Accept", "application/json")
 
 	logrus.Debugf("Confluence page API URL: %s", url)
-
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return ConfluencePage{}, fmt.Errorf("failed to make request: %w", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,6 +76,7 @@ type ConfluenceConfig struct {
 	ParentPageMappings []ParentPageMapping `yaml:"parent_page_mappings"` // Per-parent-page knowledge mappings
 	PageLimit          int                 `yaml:"page_limit"`
 	IncludeAttachments bool                `yaml:"include_attachments"`
+	UseMarkdownParser  bool                `yaml:"use_mardown_parser"`
 }
 
 // LocalFolderConfig defines local folder adapter settings


### PR DESCRIPTION
Added an option for Parsing Html To markdown.
Changed the default page fetching to export_view instead of view to include more data

Now Html Tables actually have pretty Markdown formatting
