### PR TITLE
feat: Add file retrieval and polling to OpenWebUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,10 +301,9 @@ confluence:
 
 local_folders:
   enabled: true
-  folders:
-    - "/path/to/local/docs"
-    - "/path/to/notes"
-  knowledge_id: "local-knowledge-base"
+  mappings:
+    - folder_path: "/path/to/local/docs"
+      knowledge_id: "local-knowledge-base"
 ```
 
 ## Configuration

--- a/internal/mocks/mocks.go
+++ b/internal/mocks/mocks.go
@@ -11,6 +11,7 @@ import (
 // MockOpenWebUIClient is a mock implementation of OpenWebUI client
 type MockOpenWebUIClient struct {
 	UploadFileFunc              func(ctx context.Context, filename string, content []byte) (*openwebui.File, error)
+	GetFileFunc                 func(ctx context.Context, fileID string) (*openwebui.File, error)
 	ListKnowledgeFunc           func(ctx context.Context) ([]*openwebui.Knowledge, error)
 	AddFileToKnowledgeFunc      func(ctx context.Context, knowledgeID, fileID string) error
 	RemoveFileFromKnowledgeFunc func(ctx context.Context, knowledgeID, fileID string) error
@@ -48,6 +49,36 @@ func (m *MockOpenWebUIClient) UploadFile(ctx context.Context, filename string, c
 		Status:        true,
 		Path:          "/app/backend/data/uploads/mock-file-id_" + filename,
 		AccessControl: nil,
+	}, nil
+}
+
+// GetFile mocks the GetFile method
+func (m *MockOpenWebUIClient) GetFile(ctx context.Context, fileID string) (*openwebui.File, error) {
+	if m.GetFileFunc != nil {
+		return m.GetFileFunc(ctx, fileID)
+	}
+	return &openwebui.File{
+		ID:       fileID,
+		Filename: "mock-file.md",
+		UserID:   "test-user",
+		Hash:     "mock-hash",
+		Data: struct {
+			Status string `json:"status"`
+		}{
+			Status: "processed", // Default to processed status
+		},
+		Meta: struct {
+			Name        string                 `json:"name"`
+			ContentType string                 `json:"content_type"`
+			Size        int64                  `json:"size"`
+			Data        map[string]interface{} `json:"data"`
+		}{
+			Name:        "mock-file.md",
+			ContentType: "text/markdown",
+			Size:        100,
+			Data:        map[string]interface{}{},
+		},
+		Status: true,
 	}, nil
 }
 

--- a/internal/openwebui/interface.go
+++ b/internal/openwebui/interface.go
@@ -7,6 +7,7 @@ import (
 // ClientInterface defines the interface for OpenWebUI client operations
 type ClientInterface interface {
 	UploadFile(ctx context.Context, filename string, content []byte) (*File, error)
+	GetFile(ctx context.Context, fileID string) (*File, error)
 	ListKnowledge(ctx context.Context) ([]*Knowledge, error)
 	AddFileToKnowledge(ctx context.Context, knowledgeID, fileID string) error
 	RemoveFileFromKnowledge(ctx context.Context, knowledgeID, fileID string) error


### PR DESCRIPTION
- Add file‑processing polling helper to confirm upload completion before further actions.
- Implement `GetFile` endpoint to fetch file metadata by ID.
- Enhance upload flows with detailed debug logging and proper response formatting.
- Expand OpenWebUI client mock with a `GetFile` method and optional hook for test customization.
- Provide a default mock file response with processed status and sample metadata.