### PR TITLE
Add arm64 image support

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -29,7 +29,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64, linux/arm64
           registry: ghcr.io
           push: ${{ github.event_name != 'pull_request' }}
           tags: ghcr.io/${{ env.LOWER_REPO }}:latest


### PR DESCRIPTION
This publishes an `arm64` image alongside the existing `amd64` build.
Verified by making the change, building, and running on an arm64 machine.